### PR TITLE
Menu de login - Correction DOM - Fermeture d'un div

### DIFF
--- a/Serveur/web/login.php
+++ b/Serveur/web/login.php
@@ -147,10 +147,10 @@ else {
                                   </div>
                                 </div>
                         </div>
-
+				
 			<p>Groupe</p>
 			<input class="input-medium disabled" disabled="disabled" value="<?php echo Personne::$ROLES[$utilisateur->getPersonne()->getRole()]; ?> " />
-		</fieldset>
+		</div></fieldset>
 
 	</form>
     </div>


### PR DESCRIPTION
Modif' mineure.
Un _div_ était pas fermé dans le menu de login. Merci le validateur W3.
