### PR TITLE
Remplacement des liens vers modules non fonctionnels

### DIFF
--- a/Serveur/web/a_propos.php
+++ b/Serveur/web/a_propos.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * -----------------------------------------------------------
  * Vue - A PROPOS
@@ -155,7 +155,7 @@
 														<h4>Inscription aux simulations d'entretiens</h4>
 														<p class="justify">Ces simulations, proposées grâcieusement par des entreprises partenaires, te permettent de t'entrainer à l'incontournable exercice de l'entretien professionnel, face à des RH expérimentés et là pour te conseiller.<br/>
 														Inscris-toi rapidement aux différentes sessions proposées !</p>
-														<p class="centre"><a class="btn btn-inverse" href="index.php?page=Entretiens_Etudiant" disabled title="Service en cours de finition. Marie Rosain se charge des inscriptions en attendant, merci de la contacter.">Accéder</a></p>
+														<p class="centre"><<?php /**a*/?>button class="btn btn-inverse" <?php /**href="index.php?page=Entretiens_Etudiant"*/?> disabled title="Service en cours de finition. Marie Rosain se charge des inscriptions en attendant, merci de la contacter.">Accéder</<?php /**a*/?>button></p>
 													</div>
 												</div>
 											</div>

--- a/Serveur/web/conferences/php/presentation.php
+++ b/Serveur/web/conferences/php/presentation.php
@@ -11,6 +11,8 @@
 ?>
 
 <div id="conf" class="module_entr">
+	<p class="alert alert-block alert-warning">Désolé, cette page est encore en cours d'élaboration. Merci de votre compréhension.</p>
+	<?php /**	
 	<div class="row">
 		<div class="span12">
 			<div class="hero-unit">
@@ -93,4 +95,5 @@ Nulla et erat arcu. Ut vulputate, erat in blandit hendrerit, augue ante dignissi
 			
 		</div>
 	</div>
+	*/ ?>
 </div>

--- a/Serveur/web/entretien/php/entretienEtudiant.php
+++ b/Serveur/web/entretien/php/entretienEtudiant.php
@@ -26,6 +26,11 @@ else if($utilisateur->getPersonne()->getRole() != Personne::ADMIN &&
 ?>
 <div id="entretiens">
 	<h1>Simulations d'entretiens</h1>
+	<p class="alert alert-block alert-warning">
+		Désolé, ce service est actuellement en cours de finition. Marie Rosain se charge des inscriptions en attendant, merci de la contacter.<br/>
+		Pour en savoir plus, consultez la page du Département : <a title="IF - Simulations d'entretiens" href="http://if.insa-lyon.fr/entreprise/simulation-entretiens">if.insa-lyon.fr/entreprise/simulation-entretiens</a>.
+	</p>
+	<?php /**
 	<div class="alert alert-block alert-info">
 					<h4 class="alert-heading">Inscription</h4>
 					Afin de faire votre demande d'inscription à des sessions de simulation d'entretiens, vous pouvez choisir la date souhaitée via le calendrier.<br/>
@@ -72,12 +77,15 @@ else if($utilisateur->getPersonne()->getRole() != Personne::ADMIN &&
 	});
 
 	</script>
+*/ ?>
 </div>
 
-
+<?php /**
 <?php
 inclure_fichier('entretien', 'inscription', 'js');
 inclure_fichier('entretien', 'jquery.datePicker', 'js');
 inclure_fichier('entretien', 'date', 'js');
 inclure_fichier('entretien', 'datePicker', 'css');
 ?>
+
+*/ ?>

--- a/Serveur/web/entretien/php/presentation.php
+++ b/Serveur/web/entretien/php/presentation.php
@@ -26,7 +26,7 @@
 			<p class="justify">
 				Les simulations d'entretiens ont lieu au département, hors temps scolaire. L'entreprise offre un certain nombre de créneaux durant lesquels les recruteurs dépêchés rencontreront les étudiants préalablement inscrits.</p>
 			<p class="justify">L'entretien se termine généralement par un échange entre l'étudiant et le professionnel, ce dernier pouvant revenir sur la prestation de l'élève, dresser son profil, prodiguer des conseils, ...</p>
-			<p class="justify">L'exercice est pris avec sérieux par les étudiants, pour qui il représente un entrainement efficace à cet épreuve subtile, et peu aussi parfois être l'occasion d'un premier échange avec une entreprise l'intéressant.</p>
+			<p class="justify">L'exercice est pris avec sérieux pour les étudiants, pour qui il représente un entrainement efficace à cet exercice subtil, et peu aussi parfois être l'occasion d'un premier échange avec une entreprise l'intéressant.</p>
 		</div>
 		<div id="infoRif" class="span8">
 			<h2><i class="icon icon-search icon-white"></i> Informations</h2>
@@ -48,8 +48,8 @@
 				L'AEDI servant d'intermédiaire entre les entreprises et le Département Informatique pour ce service, nous mettons à votre disposition un formulaire d'inscription que vous trouverez à l'adresse ci-dessous.<br/>
 				Une fois le formulaire remplis, celui-ci est transmis au Département qui vous donnera réponse dans les plus brefs délais.
 			</p>
-			<p class="centre"><a href="index.php?page=Entretiens_Entreprise_Inscription" class="btn btn-large btn-primary" disabled title="Service en cours de finition. Merci de consulter la page du Département pour vous inscrire en attendant : if.insa-lyon.fr/entreprise/simulation-entretiens. Merci de votre compréhension."><strong><i class="icon-pencil icon-white"></i> Formulaire d'inscription</strong></a></p>
-			<p style="color: #500; font-size: 0.9em;text-align:center;">Service en cours de finition. Merci de consulter la <a title="IF - Simulations d'entretiens" href="http://if.insa-lyon.fr/entreprise/simulation-entretiens" style="color: #500; text-decoration:underline;">page du Département</a> pour vous inscrire en attendant. Merci de votre compréhension.</p>
+			<p class="centre"><<?php /**a*/ ?>button <?php /**href="index.php?page=Entretiens_Entreprise_Inscription"*/ ?> class="btn btn-large btn-primary" disabled title="Service en cours de finition. Merci de consulter la page du Département pour vous inscrire en attendant : if.insa-lyon.fr/entreprise/simulation-entretiens. Merci de votre compréhension."><strong><i class="icon-pencil icon-white"></i> Formulaire d'inscription</strong></<?php /**a*/ ?>button></p>
+			<p class="alert alert-block alert-warning">Désolé, ce service est actuellent en cours de finition. Merci de consulter la <a title="IF - Simulations d'entretiens" href="http://if.insa-lyon.fr/entreprise/simulation-entretiens">page du Département</a> pour vous inscrire en attendant. Merci de votre compréhension.</p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
- Mise en commentaire PHP des liens vers les modules non en production.
  - Les boutons pour les Entretiens (module non en prod' mais toujours d'actualité) sont toujours là, mais _disabled_ et ne menant à rien.
- Ajout de messages explicatifs, décrivant des solutions temporaires.

Seul le module Entretiens était concerné, les RIFs et la CVthèque ayant été traitées (je crois pas qu'il y a d'oubli, à checker).
