### PR TITLE
Fix absolute path for logs

### DIFF
--- a/config/log4php.xml
+++ b/config/log4php.xml
@@ -2,8 +2,7 @@
 <configuration xmlns="http://logging.apache.org/log4php/">
     <appender name="default" class="LoggerAppenderFile">
         <layout class="LoggerLayoutTTCC" />
-        <param name="file" value="/home/aedi/Documents/IFAEDI/S.I/Serveur/web/logs/my.log" />
-	<!-- <param name="file" vamue="my.log" /> -->
+        <param name="file" value="logs/my.log" />
         <param name="append" value="true" />
     </appender>
     <root>


### PR DESCRIPTION
Correction du bug qui affiche ce message d'erreur en haut de chaque page : 

> Warning: mkdir(): Permission denied in /data/www/ifaedi/html/commun/php/log4php/appenders/LoggerAppenderFile.php on line 72
> 
> Warning: fopen(/home/aedi/Documents/IFAEDI/S.I/Serveur/web/logs/my.log): failed to open stream: No such file or directory in /data/www/ifaedi/html/commun/php/log4php/appenders/LoggerAppenderFile.php on line 76
