### PR TITLE
[Login] Correction du nom de la variable REMOTE_ADDR

### DIFF
--- a/commun/ajax/login.cible.php
+++ b/commun/ajax/login.cible.php
@@ -43,7 +43,7 @@ if( @isset( $_GET['action'] ) ) {
 					/* Authentification foirée */
 					case Authentification::ERR_ID_INVALIDE:
 						$val = genererReponseStdJSON( 'fail', 'Identifiants non valides.' );
-						$logger->warn( "Tentative d'authentification échouée. - ".$_SERVER['REMOTE_ADD'] );
+						$logger->warn( "Tentative d'authentification échouée. - ".$_SERVER['REMOTE_ADDR'] );
 						break;
 					case Authentification::ERR_AMBIGUITE:
 						$val = genererReponseStdJSON( 'error', 'Une ambiguité est survenue lors de la procédure d\'authentification.' );


### PR DESCRIPTION
Une typo dans le nom de la variable: REMOTE_ADD au lieu de REMOTE_ADDR.
