### PR TITLE
<Contenu> Améliorations typographiques (Fix #55)

### DIFF
--- a/a_propos.php
+++ b/a_propos.php
@@ -29,32 +29,32 @@
 					<div class="tab-pane active" id="about-asso">
 						<div class="hero-unit">
 							<h1>L'Association</h1>
-							<p class="justify">L'<span class="hero_motcle">AEDI</span>, l'Association des Etudiants du Département Informatique, est une figure incontournable de la vie du Département et de la faune associative de l'INSA-Lyon. Depuis 30 ans, celle-ci accompagne les étudiants en Informatique à travers leur parcours, prodiguant de multiples services et organisant des évènements variés.</p>
-							<p class="justify">Comme toute association Loi 1901, l'AEDI n'est pas à but lucratif. L'inscription est <em>gratuite</em> pour tous les étudiants IF, l'association vivant grâce aux actions qu'elle mène, ainsi qu'aux multiples partenariats tissés, notamment avec le <a title="Site Web du Département Informatique" href="if.insa-lyon.fr">Département</a> et les <a title="En savoir plus sur le parrainage" href="index.php?page=Parrainage">parrains de promotion</a>.</p>
-							<p class="justify">Chaque année, une équipe d'étudiants volontaires est élue pour reprendre sa tête, apportant ainsi de nouvelles pierres à l'édifice.</p>
+							<p>L'<span class="hero_motcle">AEDI</span>, l'Association des Etudiants du Département Informatique, est une figure incontournable de la vie du Département et de la faune associative de l'INSA-Lyon. Depuis 30 ans, celle-ci accompagne les étudiants en Informatique à travers leur parcours, prodiguant de multiples services et organisant des évènements variés.</p>
+							<p>Comme toute association Loi 1901, l'AEDI n'est pas à but lucratif. L'inscription est <em>gratuite</em> pour tous les étudiants IF, l'association vivant grâce aux actions qu'elle mène, ainsi qu'aux multiples partenariats tissés, notamment avec le <a title="Site Web du Département Informatique" href="if.insa-lyon.fr">Département</a> et les <a title="En savoir plus sur le parrainage" href="index.php?page=Parrainage">parrains de promotion</a>.</p>
+							<p>Chaque année, une équipe d'étudiants volontaires est élue pour reprendre sa tête, apportant ainsi de nouvelles pierres à l'édifice.</p>
 						</div>
 						<div style="position:relative;">
 							<h2 class="bleuBur"><i class="icon icon-star icon-white"></i> Notre Mission</h2>
-							<p class="justify">L'AEDI a pour rôle de <span class="hero_motcle">renforcer la cohésion entre les étudiants du Département Informatique, les aider dans leur cursus, et établir des contacts privilégiés avec les entreprises</span>.</p>
-							<p class="justify">Pour cela, l'AEDI profite aujourd'hui d'un riche <strong>réseau</strong> construit au cours des ans, regroupant anciens élèves investis, entreprises clés du monde informatique, et enseignants motivés. Ces ressources, mises à disposition à travers de nombreux évènements fédérateurs, comme les <a title="En savoir plus sur les RIF" href="index.php?page=RIFs_Entreprise">Rencontre IF</a> ou les <a title="En savoir plus sur les conférences" href="index.php?page=Conferences">conférences</a>, offrent des opportunités en or aux étudiants de découvrir les acteurs de l'Informatique, et leur futur employeur. Réciproquement, cela permet aux entreprises de renforcer leur présence et découvrir des profils intéressants.</p>
-							<p class="justify">S'il est primordial pour les élèves de profiter de ces occasions et de se projeter dans le futur, l'AEDI a aussi conscience de l'importance, parfois, de simplement profiter du présent, de ces années étudiantes qui passent bien trop vite. Dans cette optique sont régulierement organisés des <strong>évènements récréatifs</strong>. Intégration des nouveaux venus, sorties en ville, goûters, activités sportives, ... Toutes les occasions sont bonnes pour renforcer les liens au sein du Département, mais aussi avec l'exterieur, grâce aux bonnes relations développées avec d'autres associations étudiantes lyonnaises.</p>
-							<p class="justify">L'AEDI s'est donc donnée comme vocation d'être un <span class="hero_motcle">acteur clé</span> du Département, en aidant les étudiants dans tous les aspects de leurs etudes.</p>
+							<p>L'AEDI a pour rôle de <span class="hero_motcle">renforcer la cohésion entre les étudiants du Département Informatique, les aider dans leur cursus, et établir des contacts privilégiés avec les entreprises</span>.</p>
+							<p>Pour cela, l'AEDI profite aujourd'hui d'un riche <strong>réseau</strong> construit au cours des ans, regroupant anciens élèves investis, entreprises clés du monde informatique, et enseignants motivés. Ces ressources, mises à disposition à travers de nombreux évènements fédérateurs, comme les <a title="En savoir plus sur les RIF" href="index.php?page=RIFs_Entreprise">Rencontre IF</a> ou les <a title="En savoir plus sur les conférences" href="index.php?page=Conferences">conférences</a>, offrent des opportunités en or aux étudiants de découvrir les acteurs de l'Informatique, et leur futur employeur. Réciproquement, cela permet aux entreprises de renforcer leur présence et découvrir des profils intéressants.</p>
+							<p>S'il est primordial pour les élèves de profiter de ces occasions et de se projeter dans le futur, l'AEDI a aussi conscience de l'importance, parfois, de simplement profiter du présent, de ces années étudiantes qui passent bien trop vite. Dans cette optique sont régulierement organisés des <strong>évènements récréatifs</strong>. Intégration des nouveaux venus, sorties en ville, goûters, activités sportives, ... Toutes les occasions sont bonnes pour renforcer les liens au sein du Département, mais aussi avec l'exterieur, grâce aux bonnes relations développées avec d'autres associations étudiantes lyonnaises.</p>
+							<p>L'AEDI s'est donc donnée comme vocation d'être un <span class="hero_motcle">acteur clé</span> du Département, en aidant les étudiants dans tous les aspects de leurs etudes.</p>
 							
 							<h2 class="bleuEntr" ><i class="icon icon-heart icon-white"></i> Nos Valeurs</h2>
-							<p class="justify">L'AEDI a fait le voeu de croire profondément dans <span class="hero_motcle">le potentiel des étudiants</span> du Département Informatique. C'est pourquoi nous nous efforcons d'apporter le terreau, les opportunités, destinés à faire valoir ces talents. La <strong>diversité</strong> des profils au sein des promotions est également une caracteristique que nous chérissons et encourageons, afin de favoriser une atmosphère d'échanges et de camaraderie plûtot que de compétition.</p>
-							<p class="justify">Enfin, pur produit de <strong>l'esprit associatif</strong> de l'INSA-Lyon, l'AEDI a à cœur de faire prospérer celui-ci, en encourageant les initiatives étudiantes et les partenariats inter- et extra-campus.</p>
+							<p>L'AEDI a fait le voeu de croire profondément dans <span class="hero_motcle">le potentiel des étudiants</span> du Département Informatique. C'est pourquoi nous nous efforcons d'apporter le terreau, les opportunités, destinés à faire valoir ces talents. La <strong>diversité</strong> des profils au sein des promotions est également une caracteristique que nous chérissons et encourageons, afin de favoriser une atmosphère d'échanges et de camaraderie plûtot que de compétition.</p>
+							<p>Enfin, pur produit de <strong>l'esprit associatif</strong> de l'INSA-Lyon, l'AEDI a à cœur de faire prospérer celui-ci, en encourageant les initiatives étudiantes et les partenariats inter- et extra-campus.</p>
 						</div>
 					</div>
 					<div class="tab-pane" id="about-team">
 						<div class="hero-unit">
 							<h1>L'Equipe</h1>
-							<p class="justify">L'AEDI est gérée par une équipe d'étudiants bénévoles et actifs, élus pour un an. Chacun y apporte ses propres compétences, permettant ainsi à l'association de proposer un éventail riche et varié d'évènements et de services.</p>
+							<p>L'AEDI est gérée par une équipe d'étudiants bénévoles et actifs, élus pour un an. Chacun y apporte ses propres compétences, permettant ainsi à l'association de proposer un éventail riche et varié d'évènements et de services.</p>
 						</div>
 						<div class="row">
 							<p class="span4"><img src="commun/img/equipe/bureau.jpg" title="Le Bureau" width=350 /></p>
 							<div class="span6">
 								<h2 class="bleuBur" >Le Bureau <i class="icon icon-tag icon-white"></i></h2>
-								<p class="justify">A la tête de l'association, le Bureau coordonne les différentes équipes.<br/>
+								<p>A la tête de l'association, le Bureau coordonne les différentes équipes.<br/>
 								<small>De gauche à droite :</small></p>
 								<ul>
 									<li><span class="hero_motcle">Charlotte Pigeon</span> : Trésorière</li>
@@ -67,7 +67,7 @@
 						<div class="row">
 							<div class="span6">
 								<h2 class="bleuEntr" ><i class="icon icon-flag icon-white"></i>L'équipe Entreprise</h2>
-								<p class="justify">Chargée des relations Entreprises, l'équipe organise notamment les <a href="index.php?page=RIFs_Entreprise" title="Rencontres IF">RIFs</a>.<br/>
+								<p>Chargée des relations Entreprises, l'équipe organise notamment les <a href="index.php?page=RIFs_Entreprise" title="Rencontres IF">RIFs</a>.<br/>
 								<small>De gauche à droite :</small></p>
 								<ul>
 									<li><strong>Alina Ghermann</strong></li>
@@ -83,7 +83,7 @@
 							<p class="span4"><img src="commun/img/equipe/equipe_animation.jpg" title="L'équipe Animation" width=350 /></p>
 							<div class="span6">
 								<h2 class="bleuAnim" >L'équipe Animation <i class="icon icon-music icon-white"></i></h2>
-								<p class="justify">Cette équipe organise toute l'année des <a href="index.php?page=Evenements_Etudiant" title="Présentation des évènements">évènements</a> à destination des étudiants.<br/>
+								<p>Cette équipe organise toute l'année des <a href="index.php?page=Evenements_Etudiant" title="Présentation des évènements">évènements</a> à destination des étudiants.<br/>
 								<small>De gauche à droite :</small></p>
 								<ul>
 									<li><strong>Cédric Morin</strong></li>
@@ -96,7 +96,7 @@
 						<div class="row">
 							<div class="span6">
 								<h2 class="bleuCom" ><i class="icon icon-envelope icon-white"></i>L'équipe Communication</h2>
-								<p class="justify">Affiches, newsletters, réseaux sociaux, ... Cette équipe rend visible l'association et ses évènements sur le campus.<br/>
+								<p>Affiches, newsletters, réseaux sociaux, ... Cette équipe rend visible l'association et ses évènements sur le campus.<br/>
 								<small>De gauche à droite :</small></p>
 								<ul>
 									<li><strong>Benoit Delerue</strong></li>
@@ -110,7 +110,7 @@
 							<p class="span4"><img src="commun/img/equipe/equipe_admin.jpg" title="L'équipe Admin" width=350 /></p>
 							<div class="span6">
 								<h2 class="bleuAnim" >L'équipe Admin <i class="icon icon-eye-open icon-white"></i></h2>
-								<p class="justify">En charge du patrimoine informatique de l'AEDI, ils veillent sur le bon fonctionnement et l'amélioration des services.<br/>
+								<p>En charge du patrimoine informatique de l'AEDI, ils veillent sur le bon fonctionnement et l'amélioration des services.<br/>
 								<small>De gauche à droite :</small></p>
 								<ul>
 									<li><strong>Pierre-Henri Shoffit</strong></li>
@@ -125,7 +125,7 @@
 					<div class="tab-pane" id="about-site">
 						<div class="hero-unit">
 							<h1>Le Site-Web</h1>
-							<p class="justify">Ce site ne se résume pas à être une vitrine de notre Association et Département. Il propose l'ensemble des services informatiques de l'AEDI, à destination des étudiants et entreprises.</p>
+							<p>Ce site ne se résume pas à être une vitrine de notre Association et Département. Il propose l'ensemble des services informatiques de l'AEDI, à destination des étudiants et entreprises.</p>
 						</div>
 						
 						<div class="accordion" id="accordion-site">
@@ -145,7 +145,7 @@
 												<div class="span4">
 													<div>
 														<h4>Catalogue de stages</h4>
-														<p class="justify">Il contient les descriptions de l'ensemble des stages et PFE proposés par des entreprises au Département Informatique dans l'année.<br/>
+														<p>Il contient les descriptions de l'ensemble des stages et PFE proposés par des entreprises au Département Informatique dans l'année.<br/>
 														Grâce aux outils de recherche, tu ne pourras que trouver ton bonheur ...</p>
 														<p class="centre"><a class="btn btn-inverse" href="index.php?page=Stages_Etudiant">Accéder</a></p>
 													</div>
@@ -153,7 +153,7 @@
 												<div class="span4">
 													<div>
 														<h4>Inscription aux simulations d'entretiens</h4>
-														<p class="justify">Ces simulations, proposées grâcieusement par des entreprises partenaires, te permettent de t'entrainer à l'incontournable exercice de l'entretien professionnel, face à des RH expérimentés et là pour te conseiller.<br/>
+														<p>Ces simulations, proposées grâcieusement par des entreprises partenaires, te permettent de t'entrainer à l'incontournable exercice de l'entretien professionnel, face à des RH expérimentés et là pour te conseiller.<br/>
 														Inscris-toi rapidement aux différentes sessions proposées !</p>
 														<p class="centre"><<?php /**a*/?>button class="btn btn-inverse" <?php /**href="index.php?page=Entretiens_Etudiant"*/?> disabled title="Service en cours de finition. Marie Rosain se charge des inscriptions en attendant, merci de la contacter.">Accéder</<?php /**a*/?>button></p>
 													</div>
@@ -168,14 +168,14 @@
 												<div class="span4">
 													<div>
 														<h4>Redmine</h4>
-														<p class="justify">Cet outil de gestion permet un suivi en temps réel de l'avancement du projet. Permettant notamment d'identifier des tâches puis de logger le temps de travail, il offre un tableau de bord très utile aux chefs de projets.</p>
+														<p>Cet outil de gestion permet un suivi en temps réel de l'avancement du projet. Permettant notamment d'identifier des tâches puis de logger le temps de travail, il offre un tableau de bord très utile aux chefs de projets.</p>
 														<p class="centre"><a class="btn btn-inverse" href="http://shareif.insa-lyon.fr/redmine">Accéder</a></p>
 													</div>
 												</div>
 												<div class="span4">
 													<div>
 														<h4>Share'IF</h4>
-														<p class="justify">Il s'agit d'une plateforme Svn/Git mis à disposition par l'AEDI, permettant le travail collaboratif et le versionnage des évolutions de vos projets. La création et le partage de dépôts se font en quelques clics !</p>
+														<p>Il s'agit d'une plateforme Svn/Git mis à disposition par l'AEDI, permettant le travail collaboratif et le versionnage des évolutions de vos projets. La création et le partage de dépôts se font en quelques clics !</p>
 														<p class="centre"><a class="btn btn-inverse" href="https://shareif.insa-lyon.fr/">Accéder</a></p>
 													</div>
 												</div>
@@ -206,14 +206,14 @@
 												<div class="span4">
 													<div>
 														<h4>Rencontres IF</h4>
-														<p class="justify">Vous trouverez sur la page indiquée ci-dessous l'ensemble des informations sur cet évènement, ainsi que l'adresse pour nous contacter et discuter des détails de votre candidature. N'hésitez pas à nous joindre le plus tôt possible, afin d'être sûr d'obtenir un stand !</p>
+														<p>Vous trouverez sur la page indiquée ci-dessous l'ensemble des informations sur cet évènement, ainsi que l'adresse pour nous contacter et discuter des détails de votre candidature. N'hésitez pas à nous joindre le plus tôt possible, afin d'être sûr d'obtenir un stand !</p>
 														<p class="centre"><a class="btn btn-inverse" href="index.php?page=RIFs_Entreprise">Accéder</a></p>
 													</div>
 												</div>
 												<div class="span4">
 													<div>
 														<h4>Simulations d'entretiens</h4>
-														<p class="justify">En quelques clics, préinscrivez-vous pour organiser des simulations d'entretiens dans notre Département ! Votre demande sera traitée dans les délais les plus brefs, et transmise à l'administration du Département qui se chargera des détails logistiques.</p>
+														<p>En quelques clics, préinscrivez-vous pour organiser des simulations d'entretiens dans notre Département ! Votre demande sera traitée dans les délais les plus brefs, et transmise à l'administration du Département qui se chargera des détails logistiques.</p>
 														<p style="color: #500; font-size: 0.8em;text-align:center;">Service en cours de finition. Merci de consulter la <a title="IF - Simulations d'entretiens" href="http://if.insa-lyon.fr/entreprise/simulation-entretiens" style="color: #500; text-decoration:underline;">page du Département</a> pour vous inscrire en attendant. Merci de votre compréhension.</p>
 														<p class="centre"><a class="btn btn-small btn-inverse" href="index.php?page=Entretiens_Entreprise" disabled title="Service en cours de finition. Merci de consulter la page du Département pour vous inscrire en attendant : if.insa-lyon.fr/entreprise/simulation-entretiens. Merci de votre compréhension.">Accéder</a></p>
 													</div>

--- a/accueil.php
+++ b/accueil.php
@@ -20,9 +20,9 @@
 				</p>
 			</div>
 			<div class="well">
-				<p style="text-align:justify;"><span class="hero_motcle">AEDI</span> <small>(nf)</small> : <em>Association de l'INSA-Lyon créée pour renforcer la cohésion entre les étudiants du Département Informatique, les aider dans leur cursus, et établir des contacts privilégiés avec les entreprises.</em></p>
-				<p style="text-align:justify;">Cela fait plus de vingt-neuf ans que notre association étoffe son éventails d'évènements, de la Semaine d'Intégration des nouveaux élèves aux Rencontres IF, forum ouvert aux entreprises, en passant par le Week-End Ski, le Concert IF, le Voyage de fin d'étude, ...</p>
-				<p style="text-align:justify;">Avec à sa tête une équipe dynamique, l'AEDI s'épanouit et grandit, riche des liens qu'elle tisse avec les entreprises et anciens étudiants.</p>
+				<p><span class="hero_motcle">AEDI</span> <small>(nf)</small> : <em>Association de l'INSA-Lyon créée pour renforcer la cohésion entre les étudiants du Département Informatique, les aider dans leur cursus, et établir des contacts privilégiés avec les entreprises.</em></p>
+				<p>Cela fait plus de vingt-neuf ans que notre association étoffe son éventails d'évènements, de la Semaine d'Intégration des nouveaux élèves aux Rencontres IF, forum ouvert aux entreprises, en passant par le Week-End Ski, le Concert IF, le Voyage de fin d'étude, ...</p>
+				<p>Avec à sa tête une équipe dynamique, l'AEDI s'épanouit et grandit, riche des liens qu'elle tisse avec les entreprises et anciens étudiants.</p>
 				<p style="text-align:justify; margin-bottom:20px;"><strong>Soyez le ou la bienvenu(e) sur notre site !</strong>
 				</p>
 				<div style="width:50%; float:left; display:inline-block;" >
@@ -97,7 +97,7 @@
         </p>
         </div>
         <div class="row" style="text-align:center;">
-            <p class="span12">
+            <p class="span12 centre">
                 <embed style="margin-top:-20px;" src="./commun/img/societe_generale.swf" class="adapt-width" span=8 scale=0.60 max=800 />
             </p>
         </div>

--- a/commun/css/style.css
+++ b/commun/css/style.css
@@ -4,6 +4,10 @@ body {
     margin-top: 25px;
 }
 
+p {
+	text-align: justify;
+}
+
 /* tablesorter */
 
 
@@ -39,11 +43,6 @@ table.tablesorter thead tr .headerSortDown {
 .centre
 {
 	text-align:center;
-}
-
-.justify
-{
-	text-align:justify;
 }
 
 .comment{

--- a/conferences/php/presentation.php
+++ b/conferences/php/presentation.php
@@ -23,9 +23,9 @@
                 il est nécessaire que les étudiants apprennent par d'autres sources que l'école.
                 </p>
                 <p>
-                Pour leur faciliter la tâche, l'AEDI propose des conférences aux étudiants. Ces séminaires sont
-                proposés par des ingénieurs issus du monde de l'entreprise, qui présentent des technologies ou des
-                concepts. Ces rencontres sont à la fois profitables pour les intervenants qui améliorent leurs carnets
+                Pour leur faciliter la tâche, l'AEDI propose des conférences aux élèves. Ces séminaires sont
+                proposés par des <span class="hero_motcle">ingénieurs issus du monde de l'entreprise</span>, qui présentent des <span class="hero_motcle">technologies ou des
+                concepts</span>. Ces rencontres sont à la fois profitables pour les intervenants qui améliorent leurs carnets
                 de contacts et les étudiants qui en apprennent plus sur la société.
                 </p>
 			</div>
@@ -34,21 +34,17 @@
 	<div class="row">
 		<div class="span4">
 			<h2><i class="icon icon-bookmark icon-white"></i> Concept</h2>
-			<p class="justify">
-            Le concept des conférences est de faire se rencontrer les étudiants et les entreprises tout en permettant
-            aux futurs ingénieurs d'actualiser leurs connaissances du monde de l'entreprise. Pour cela, des employés
-            d'une société viennent à l'INSA les jeudis après-midis, effectuent leurs présentations devant des
-            étudiants inscrits de leur plein gré pour assister à la conférence. A la fin de cette dernière, ingénieurs et
-            étudiants discutent de manière informelle, parfois autour d'un buffet. Suite à cette expérience, les parties
-            prenantes repartent avec de nouveaux contacts professionnels.
-			</p>
+			<p>Le concept des conférences est de faire se rencontrer les étudiants et les entreprises tout en permettant
+            aux futurs ingénieurs d'<strong>actualiser leurs connaissances du monde de l'entreprise</strong>.</p>
+			<p>Pour cela, des employés d'une société viennent à l'INSA les jeudis après-midis, effectuent leurs présentations devant des
+            étudiants inscrits de leur plein gré pour assister à la conférence.</p> 
+			<p>A la fin de celle-ci, ingénieurs et étudiants discutent de manière informelle, parfois autour d'un buffet. Suite à cette expérience, les parties
+            prenantes repartent avec de <strong>nouveaux contacts</strong> professionnels.</p>
 		</div>
 		<div id="infoRif" class="span8">
 			<h2><i class="icon icon-search icon-white"></i> Informations</h2>
-
             <p>
-            Vous êtes une entreprise et vous êtes intéressés pour présenter cette dernière, ou une méthode, un thème
-            ou une technologie que vous maîtrisez en interne? Voici les informations qui vous intéressent.
+            Vous êtes une entreprise et vous êtes intéressés pour présenter cette dernière, ou une méthode, un thème ou une technologie que vous maîtrisez en interne? Voici les informations qui vous intéressent.
             </p>
 
 			<h3>Dates possibles</h3>

--- a/conferences/php/presentation.php
+++ b/conferences/php/presentation.php
@@ -55,15 +55,15 @@
 			<h3>Tarifs</h3>
             <p>
             Les tarifs pour présenter une conférence thématique dépendent du statut de votre entreprise par rapport
-            à l'AEDI: vous aurez ainsi accès à un tarif différent si votre société parraine une des trois promotions
+            à l'AEDI : vous aurez ainsi accès à un tarif différent si votre société parraine une des trois promotions
             en cours, si celle-ci paye la taxe d'apprentisssage au département IF ou si vous n'êtes dans aucune
             de ces deux situations.
             </p>
             <p>
-            Ces tarifs comprennent les prestations suivantes:
+            Ces tarifs comprennent les prestations suivantes :
                 <ul>
-                    <li>Communication auprès des étudiants: campagnes d'affichage, mailing listes, etc.</li>
-                    <li>Logistique liée à la conférence: réservation / mise à disposition de la salle, accueil, etc.</li>
+                    <li>Communication auprès des étudiants : campagnes d'affichage, mailing listes, etc.</li>
+                    <li>Logistique liée à la conférence : réservation / mise à disposition de la salle, accueil, etc.</li>
                     <li>Réservation et mise en place d'un buffet (avec supplément).</li>
                 </ul>
             </p>

--- a/cvtheque/php/presentation.php
+++ b/cvtheque/php/presentation.php
@@ -24,10 +24,10 @@
 	<div class="row">
 		<div class="span4">
 			<h2><i class="icon icon-bookmark icon-white"></i> Concept</h2>
-			<p class="justify">
+			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus in erat a dui auctor <strong>eleifend bibendum et felis</strong>. Curabitur rhoncus scelerisque felis non vehicula. Suspendisse potenti. Maecenas velit dolor, porttitor sed tincidunt at, pharetra at lacus. Integer id sapien enim, interdum auctor ligula. In pulvinar nulla ut dolor ornare bibendum. Fusce et odio eleifend nisl placerat vehicula.
 			</p>
-			<p class="justify">
+			<p>
 				
 Nulla et erat arcu. Ut vulputate, erat in blandit hendrerit, augue ante dignissim felis, et elementum tellus tellus nec nulla. Suspendisse faucibus nulla vitae tellus aliquam eget scelerisque neque ornare. Sed convallis lobortis mollis. Etiam in dolor vitae dolor molestie suscipit. Aliquam erat volutpat. Sed mi elit, egestas ut <span class="hero_motcle">dignissim vulputate</span>, eleifend quis massa. Sed a purus ipsum. Etiam pulvinar tincidunt eros, ultrices dapibus dolor gravida ac.
 			</p>

--- a/cvtheque/php/presentationTemp.php
+++ b/cvtheque/php/presentationTemp.php
@@ -28,13 +28,13 @@
 			<p class="centre" style="font-size:10em;">
 				<br/><br/><br/>?
 			</p>
-			<p class="justify">
+			<p>
 		</div>
 		<div id="infoRif" class="span8">
 			<h2><i class="icon icon-search icon-white"></i> Nous aider</h2>
 			
-			<p class="justify">Ce projet est encore en phase d'étude. Plusieurs formules et formats ont déjà été proposés, et nous étudions l'intérêt de chacun. Néanmoins, en tant qu'acteurs potentiels de cette offre, votre avis nous intéresse beaucoup.</p>
-			<p class="justify">Nous serons ainsi heureux de pouvoir prendre en compte vos suggestions, émises à l'adresse suivante :</p>
+			<p>Ce projet est encore en phase d'étude. Plusieurs formules et formats ont déjà été proposés, et nous étudions l'intérêt de chacun. Néanmoins, en tant qu'acteurs potentiels de cette offre, votre avis nous intéresse beaucoup.</p>
+			<p>Nous serons ainsi heureux de pouvoir prendre en compte vos suggestions, émises à l'adresse suivante :</p>
 			<p class="centre"><a href="#" e-name="aedi.bureau" class="e-noBot btn btn-large btn-info" e-domain="listes.insa-lyon.fr"><i class="icon-eye-open icon-white"></i> Afficher Email</a></p>
 		</div>
 	</div>

--- a/entretien/php/presentation.php
+++ b/entretien/php/presentation.php
@@ -16,35 +16,35 @@
 			<div class="hero-unit">
 				<h1>Simulations d'entretiens</h1>
 				<p>Ces simulations, proposées par des entreprises volontaires, permettent aux étudiant(e)s de s'initier au délicat exercice de l'entretien professionnel, en bénéficiant des conseils de R.H aguérri(e)s.</p>
-				<p>Pour les entreprises, cela offre l'occasion de renforcer leur image auprès des étudiants et découvrir de nouveaux profils !</p>
+				<p>Pour les entreprises, cela offre l'occasion de <span class="hero_motcle">renforcer leur image</span> auprès des étudiants et <span class="hero_motcle">découvrir de nouveaux profils</span> !</p>
 			</div>
 		</div>
 	</div>
 	<div class="row">
 		<div class="span4">
 			<h2><i class="icon icon-bookmark icon-white"></i> Concept</h2>
-			<p class="justify">
+			<p>
 				Les simulations d'entretiens ont lieu au département, hors temps scolaire. L'entreprise offre un certain nombre de créneaux durant lesquels les recruteurs dépêchés rencontreront les étudiants préalablement inscrits.</p>
-			<p class="justify">L'entretien se termine généralement par un échange entre l'étudiant et le professionnel, ce dernier pouvant revenir sur la prestation de l'élève, dresser son profil, prodiguer des conseils, ...</p>
-			<p class="justify">L'exercice est pris avec sérieux pour les étudiants, pour qui il représente un entraînement efficace à cet exercice subtil, et peu aussi parfois être l'occasion d'un premier échange avec une entreprise l'intéressant.</p>
+			<p>L'entretien se termine généralement par un échange entre l'étudiant et le professionnel, ce dernier pouvant revenir sur la <strong>prestation de l'élève, dresser son profil, prodiguer des conseils, ... </strong></p>
+			<p>L'exercice est pris avec  sérieux par les étudiants, pour qui il représente un <strong>entraînement efficace à cet exercice subtil</strong>, et peu aussi parfois être l'occasion d'un premier <strong>échange</strong> avec une entreprise l'intéressant.</p>
 		</div>
 		<div id="infoRif" class="span8">
 			<h2><i class="icon icon-search icon-white"></i> Informations</h2>
 
 			<h3>Dates possibles</h3>
-			<p class="justify">
+			<p>
 				Les Jeudis après-midi, hors vacances scolaires.
 			</p>
 
 			
 			<h3>Contact</h3>
-			<p class="justify">Pour plus d'informations concernant cet évènement, nous vous invitons à consulter le site web du Département :</p>
+			<p>Pour plus d'informations concernant cet évènement, nous vous invitons à consulter le site web du Département :</p>
 			<p class="centre"><a href="http://if.insa-lyon.fr/entreprise/simulation-entretiens" class="btn btn-large btn-primary" ><i class="icon-search icon-white"></i> En savoir plus</a></p>
-			<p class="justify">Vous pouvez également contacter notre Bureau, qui saura vous conseillez : <a href="#" e-name="aedi.bureau" class="e-noBot btn btn-mini btn-info" e-domain="listes.insa-lyon.fr"><i class="icon-eye-open icon-white"></i> Afficher Email</a></p>
+			<p>Vous pouvez également contacter notre Bureau, qui saura vous conseillez : <a href="#" e-name="aedi.bureau" class="e-noBot btn btn-mini btn-info" e-domain="listes.insa-lyon.fr"><i class="icon-eye-open icon-white"></i> Afficher Email</a></p>
 			
 		
 			<h2><i class="icon icon-pencil icon-white"></i> Inscription</h2>
-			<p class="justify">
+			<p>
 				L'AEDI servant d'intermédiaire entre les entreprises et le Département Informatique pour ce service, nous mettons à votre disposition un formulaire d'inscription que vous trouverez à l'adresse ci-dessous.<br/>
 				Une fois le formulaire remplis, celui-ci est transmis au Département qui vous donnera réponse dans les plus brefs délais.
 			</p>

--- a/evenements/php/presentation.php
+++ b/evenements/php/presentation.php
@@ -29,13 +29,13 @@
 				<div class="tab-pane active" id="divertissements">
 					<div class="hero-unit">
 						<h1>Divertissements</h1>
-						<p class="justify">Convivialité, camaraderie, épanouissement, ... Nous jugeons ces notions indissociables d'une scolarité réussie. C'est pourquoi l'AEDI prend à cœur de tisser des liens au sein des promotions et avec l'extérieur, en multipliant les évènements récréatifs, qu'ils soient de petite ou grosse envergure. Tu trouveras ci-dessous les exemples les plus emblématiques.</p>
+						<p>Convivialité, camaraderie, épanouissement, ... Nous jugeons ces notions indissociables d'une scolarité réussie. C'est pourquoi l'AEDI prend à cœur de tisser des liens au sein des promotions et avec l'extérieur, en multipliant les évènements récréatifs, qu'ils soient de petite ou grosse envergure. Tu trouveras ci-dessous les exemples les plus emblématiques.</p>
 					</div>
 					<div class="row">
 						<p class="span4"><img src="evenements/img/inte3.jpg" title="En IF, les musiciens sont à l'honneur !" /></p>
 						<div class="span6 presentation">
 							<h2>L'Intégration<i class="icon icon-flag icon-white"></i></h2>
-							<p class="justify">Afin de faire découvrir leur nouvel environnement aux nouveaux IFs, et d'aider à tisser les premiers liens, des volontaires organisent à la rentrée, avec l'aide du parrain, une semaine d'évènements variés, s'achevant sur l'incontournable <strong>Week-End d'Intégration</strong>.<br/>
+							<p>Afin de faire découvrir leur nouvel environnement aux nouveaux IFs, et d'aider à tisser les premiers liens, des volontaires organisent à la rentrée, avec l'aide du parrain, une semaine d'évènements variés, s'achevant sur l'incontournable <strong>Week-End d'Intégration</strong>.<br/>
 							<small>Date : Semaine de la rentrée</small></p>
 						</div>
 					</div>
@@ -43,11 +43,11 @@
 						<div class="span6">
 							<div class="presentation" style="margin-bottom: 10px;">
 								<h2><i class="icon icon-music icon-white"></i> Le Concert IF</h2>
-								<p class="justify">Les IFs ont du talent ! Prouve-le en participant à ce concert, avec ton groupe ou d'autres musiciens du Département ! <small>Date : Début Décembre</small></p>
+								<p>Les IFs ont du talent ! Prouve-le en participant à ce concert, avec ton groupe ou d'autres musiciens du Département ! <small>Date : Début Décembre</small></p>
 							</div>
 							<div class="presentation">
 								<h2><i class="icon icon-asterisk icon-white"></i> Le Week-End Ski</h2>
-								<p class="justify">Un week-end de folie où les étudiants IF se retrouvent pour profiter de la montagne et de la fondue ! Bonne ambiance assurée ! <small>Date : Fin Janvier</small></p>
+								<p>Un week-end de folie où les étudiants IF se retrouvent pour profiter de la montagne et de la fondue ! Bonne ambiance assurée ! <small>Date : Fin Janvier</small></p>
 							</div>
 						</div>
 						<p class="span4"><img src="evenements/img/inte.jpg" title="Sortie ensoleillée lors de l'Intégration." /></p>
@@ -57,11 +57,11 @@
 						<div>
 							<div class="span6 presentation" style="margin-bottom: 10px;">
 								<h2>La Soirée Post-Partiels <i class="icon icon-glass icon-white"></i></h2>
-								<p class="justify"><em>Après l'effort, le réconfort !</em> Organisée en fin d’année, cette soirée rassemble plusieurs centaines de participants de plusieurs campus ... <small>Date : Fin Avril</small></p>
+								<p><em>Après l'effort, le réconfort !</em> Organisée en fin d’année, cette soirée rassemble plusieurs centaines de participants de plusieurs campus ... <small>Date : Fin Avril</small></p>
 							</div>
 							<div class="span6 presentation">
 								<h2>Le Barbecue de Fin d'Année <i class="icon icon-fire icon-white"></i></h2>
-								<p class="justify">Soirée au coin du feu avec les camarades de promo pour célébrer l'arrivée de l'été, avant le début des stages. <small>Date : Fin Mai</small></p>
+								<p>Soirée au coin du feu avec les camarades de promo pour célébrer l'arrivée de l'été, avant le début des stages. <small>Date : Fin Mai</small></p>
 							</div>
 						</div>
 					</div>
@@ -69,11 +69,11 @@
 						<div class="span6">
 							<div class="presentation" style="margin-bottom: 10px;">
 								<h2><i class="icon icon-star icon-white"></i> La Remise des Diplômes</h2>
-								<p class="justify">Véritable cérémonie durant laquelle sera remis ton diplôme tant mérité, avec le reste de ta promo et ta famille. <small>Date : Début Février</small></p>
+								<p>Véritable cérémonie durant laquelle sera remis ton diplôme tant mérité, avec le reste de ta promo et ta famille. <small>Date : Début Février</small></p>
 							</div>
 							<div class="presentation">
 								<h2><i class="icon icon-plane icon-white"></i> Le Voyage de Fin d'Etude</h2>
-								<p class="justify">Dernière aventure de la promo, l’AEDI organise ce voyage qui aura lieu pendant votre PFE (dernier stage en 5ème année). <small>Date : Juin</small></p>
+								<p>Dernière aventure de la promo, l’AEDI organise ce voyage qui aura lieu pendant votre PFE (dernier stage en 5ème année). <small>Date : Juin</small></p>
 							</div>
 						</div>
 						<p class="span4"><img src="evenements/img/rdd.jpg" title="La Remise des Diplômes, plein d'émotions !" width=350/></p>
@@ -83,7 +83,7 @@
 				<div class="tab-pane" id="entreprises">
 					<div class="hero-unit">
 						<h1>Entreprises</h1>
-						<p class="justify">
+						<p>
 							L'AEDI est un acteur de premier plan dans le démarche professionnalisante menée par le Département Informatique durant la formation. En proposant diverses occasions d'échanger de maniere privilegiée avec des ingenieurs et acteurs du monde informatique, nous espérons ainsi t'aider à acquérir les ressources professionnelles nécessaires à l'épanouissement de ta carrière.
 						</p>
 					</div>
@@ -91,7 +91,7 @@
 						<p class="span4"><img src="evenements/img/rif.jpg" title="Les RIFs sont une occasion unique pour rencontrer de grandes entreprises." /></p>
 						<div class="span6 presentation">
 							<h2>Les Rencontres IF<i class="icon icon-retweet icon-white"></i></h2>
-							<p class="justify">Plus d'une vingtaine d'entreprises sont invitées au sein du Département afin de venir à la rencontre des étudiants ! La journée, banalisée pour l'évènement, te permettra de venir te renseigner, poser des questions, prendre des contacts, et peut-être obtenir ton futur stage ou emploi !<br/>
+							<p>Plus d'une vingtaine d'entreprises sont invitées au sein du Département afin de venir à la rencontre des étudiants ! La journée, banalisée pour l'évènement, te permettra de venir te renseigner, poser des questions, prendre des contacts, et peut-être obtenir ton futur stage ou emploi !<br/>
 							Il s'agit d'une chance unique pour cotoyer de grandes entreprises de l'informatique, alors prépare dès à présent tes CV et ton costume !<br/>
 							<small>Date : Mi Janvier</small></p>
 						</div>
@@ -99,7 +99,7 @@
 					<div class="row">
 						<div class="span6 presentation">
 							<h2><i class="icon icon-volume-up icon-white"></i> Les Conférences</h2>
-							<p class="justify">Durant une heure ou deux, des entreprises viennent présenter leurs métiers, ou des concepts qu'elles ont à cœur. C'est l'opportunité de découvrir les tendances actuelles qui agitent le monde professionnel, et peut-être d'échanger de manière conviviale, autour d'un toast, avec des experts dans leur domaine !<br/>
+							<p>Durant une heure ou deux, des entreprises viennent présenter leurs métiers, ou des concepts qu'elles ont à cœur. C'est l'opportunité de découvrir les tendances actuelles qui agitent le monde professionnel, et peut-être d'échanger de manière conviviale, autour d'un toast, avec des experts dans leur domaine !<br/>
 							<small>Date : Les Jeudis après-midi</small></p>
 						</div>
 						<p class="span4"><img src="evenements/img/conf.jpg" title="Nouvelles technologies ou orientations professionnelles ... Les conférences proposent des sujets au goût de chacun." /></p>
@@ -108,7 +108,7 @@
 						<p class="span4"><img src="evenements/img/simulation.jpg" title="Grâce au Département et à l'AEDI, vous aurez la chance de rencontrer de nombreux professionnels et bénéficier de leurs conseils." /></p>
 						<div class="span6 presentation">
 							<h2>Les Simulations d'entretiens <i class="icon icon-comment icon-white"></i></h2>
-							<p class="justify">Proposées par des sociétés partenaires, ces simulations te permettent de mettre ton argumentaire et ton charisme à l'épreuve de recruteurs expérimentés, qui te prodigueront remarques et conseils, et t'aideront peut-être même à mieux cibler ton propre profil.<br/>
+							<p>Proposées par des sociétés partenaires, ces simulations te permettent de mettre ton argumentaire et ton charisme à l'épreuve de recruteurs expérimentés, qui te prodigueront remarques et conseils, et t'aideront peut-être même à mieux cibler ton propre profil.<br/>
 							<small>Date : Les Jeudis après-midi</small></p>
 						</div>
 					</div>
@@ -117,7 +117,7 @@
 				<div class="tab-pane" id="salle-detente">
 					<div class="hero-unit">
 						<h1>Salle Détente</h1>
-						<p class="justify">Sanctuaire au cœur du Département (2ème étage), tu y passeras ton temps libre <small>(peut-être tes nuits)</small>. Outre les canapés, l'AEDI met à ta disposition des jeux <small>(une asso renégate de coincheurs hanterait les lieux ...)</small> et du café <small>(ton futur meilleur ami, si ce n'est pas déja le cas).</small></p>
+						<p>Sanctuaire au cœur du Département (2ème étage), tu y passeras ton temps libre <small>(peut-être tes nuits)</small>. Outre les canapés, l'AEDI met à ta disposition des jeux <small>(une asso renégate de coincheurs hanterait les lieux ...)</small> et du café <small>(ton futur meilleur ami, si ce n'est pas déja le cas).</small></p>
 					</div>
 					<div class="row">
 						<div class="span10">

--- a/parrainage/php/presentation.php
+++ b/parrainage/php/presentation.php
@@ -16,7 +16,7 @@
 			<div class="hero-unit">
 				<h1>Parrainage</h1>
 				<p>
-					Le parrainage est un accord tripartite entre une entreprise, le Département Informatique de l'INSA-Lyon, et l'AEDI, ayant pour objectif de tisser une relation étroite entre les étudiants et membres de l'entreprise, bénéfique pour tous.
+					Le parrainage est un <span class="hero_motcle">accord tripartite</span> entre une entreprise, le Département Informatique de l'INSA-Lyon, et l'AEDI, ayant pour objectif de tisser une relation étroite entre les étudiants et membres de l'entreprise, bénéfique pour tous.
 				</p>
 			</div>
 		</div>
@@ -24,12 +24,12 @@
 	<div class="row">
 		<div class="span4">
 			<h2><i class="icon icon-bookmark icon-white"></i> Concept</h2>
-			<p class="justify">
+			<p>
 				Chaque année, la nouvelle promotion entrante au Département Informatique (3 IF – Première année du cycle Ingénieur) a l’opportunité d’être parrainée par une entreprise, pour les trois années de ce second cycle.</p>
-			<p class="justify">
+			<p>
 				En échange <span class="hero_motcle">d'une présence et d'une visibilité assurées</span> au sein du Département et des évènements de l'AEDI, l’entreprise parrainant s’engage à co-organiser des évènements particuliers pour les étudiants (conférence de présentation, weekend d’intégration, ...), et tenter au mieux de leur offrir certaines opportunités en son sein.
 			</p>
-			<p class="justify">
+			<p>
 				Cette démarche s'inscrit fortement dans la politique professionnalisante soutenue par le Département et l'AEDI. Ces trois années de collaboration entre acteurs de l'entreprise, étudiants et enseignants créent un lien fort, qui a su séduire les plus grands noms de l'informatique.
 			</p>
 		</div>
@@ -38,7 +38,7 @@
 			
 			
 			<h2><i class="icon icon-search icon-white"></i> Contact</h2>
-			<p class="justify">
+			<p>
 				Si votre société est intéressée pour encadrer une future promotion, ou si vous souhaitez de plus amples informations sur les conditions de cet accord, nous vous invitons à nous contacter via l'adresse email ci-dessous. Nous nous ferons un plaisir de dialoguer avec vous. Vous pouvez également consulter la page Web dédiée du Département, <a title="Parrainage vu par le Département" href="http://if.insa-lyon.fr/entreprise/parrainage">ici</a>.
 			</p>
 			<p class="centre"><a href="#" e-name="aedi.bureau" class="e-noBot btn btn-large btn-info" e-domain="listes.insa-lyon.fr"><strong><i class="icon-eye-open icon-white"></i> Nous Contacter</strong></a></p>


### PR DESCRIPTION
Fix #55
- Justification par défaut de tous les paragraphes _< p >_
- Suppression de la classe _justify_ devenue inutile
- Mise en avant de termes via _< strong >_ ou _< span class="hero_motcle" >_
- Aération de certains blocs en découpant en paragraphes
